### PR TITLE
Keep each stat blurred until a real nonzero figure arrives

### DIFF
--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -6,14 +6,23 @@ import ActionButton from '@/components/ui/ActionButton';
 import StarrySky from '@/components/ui/StarrySky';
 import StatsCard from '@/components/ui/StatsCard';
 import { formatTvl } from '@/lib/TvlContext';
-import { useUserbaseContext } from '@/lib/UserbaseContext';
+import { hasStatValue, useUserbaseContext } from '@/lib/UserbaseContext';
 
 export default function HeroSection() {
   const { data, loading } = useUserbaseContext();
-  const totalRevenueValue = data?.totalRevenueUsd
-    ? `$${formatTvl(data.totalRevenueUsd)}`
+
+  // A stat only leaves the blur once the backend hands us a real figure; a
+  // missing or zero value stays blurred forever rather than showing its
+  // placeholder as if it were the measurement.
+  const tvl = data?.tvl;
+  const totalRevenueUsd = data?.totalRevenueUsd;
+  const hasTvl = hasStatValue(tvl);
+  const hasTotalRevenue = hasStatValue(totalRevenueUsd);
+
+  const totalRevenueValue = hasTotalRevenue
+    ? `$${formatTvl(totalRevenueUsd)}`
     : '$00.0M';
-  const tvlValue = data?.tvl ? `$${formatTvl(data.tvl)}` : '$000.00M';
+  const tvlValue = hasTvl ? `$${formatTvl(tvl)}` : '$000.00M';
 
   return (
     <div className='relative flex h-[100vh] max-h-[1000px] min-h-[700px] w-full flex-col overflow-hidden bg-[#01020D] md:max-h-[100vh] md:min-h-[944px]'>
@@ -187,7 +196,7 @@ export default function HeroSection() {
           value={tvlValue}
           tooltipContent='Total value of deposited assets in the protocol.'
           className='hidden md:block'
-          isLoading={loading}
+          isLoading={loading || !hasTvl}
         />
 
         {/* Total Revenue Card - Desktop version */}
@@ -196,7 +205,7 @@ export default function HeroSection() {
           value={totalRevenueValue}
           tooltipContent='Total protocol revenue generated from fees.'
           className='hidden md:block'
-          isLoading={loading}
+          isLoading={loading || !hasTotalRevenue}
         />
 
         {/* Mobile Stats Layout - Fixed to bottom of viewport */}
@@ -207,7 +216,7 @@ export default function HeroSection() {
             value={tvlValue}
             tooltipContent='Total value of deposited assets in the protocol.'
             isMobile={true}
-            isLoading={loading}
+            isLoading={loading || !hasTvl}
           />
 
           {/* Total Revenue */}
@@ -216,7 +225,7 @@ export default function HeroSection() {
             value={totalRevenueValue}
             tooltipContent='Total protocol revenue generated from fees.'
             isMobile={true}
-            isLoading={loading}
+            isLoading={loading || !hasTotalRevenue}
           />
         </div>
       </div>

--- a/src/components/sections/LunarCircleSection.tsx
+++ b/src/components/sections/LunarCircleSection.tsx
@@ -5,19 +5,34 @@ import Image from 'next/image';
 
 import { BlurredLoadingText } from '@/components/ui/BlurredLoadingText';
 import { formatTvl } from '@/lib/TvlContext';
-import { useUserbaseContext, formatNumber } from '@/lib/UserbaseContext';
+import {
+  hasStatValue,
+  useUserbaseContext,
+  formatNumber,
+} from '@/lib/UserbaseContext';
 
 export default function LunarCircleSection() {
   const { data, loading } = useUserbaseContext();
-  const activeUsers = data?.uniqueUsers
-    ? formatNumber(data.uniqueUsers)
-    : '000,000';
-  const allTimeTransactions = data?.totalTransactions
-    ? formatNumber(data.totalTransactions)
+
+  // A stat only leaves the blur once the backend hands us a real figure; a
+  // missing or zero value stays blurred forever rather than showing its
+  // placeholder as if it were the measurement.
+  const tvl = data?.tvl;
+  const totalRevenueUsd = data?.totalRevenueUsd;
+  const uniqueUsers = data?.uniqueUsers;
+  const totalTransactions = data?.totalTransactions;
+  const hasTvl = hasStatValue(tvl);
+  const hasTotalRevenue = hasStatValue(totalRevenueUsd);
+  const hasUniqueUsers = hasStatValue(uniqueUsers);
+  const hasTotalTransactions = hasStatValue(totalTransactions);
+
+  const activeUsers = hasUniqueUsers ? formatNumber(uniqueUsers) : '000,000';
+  const allTimeTransactions = hasTotalTransactions
+    ? formatNumber(totalTransactions)
     : '00,000';
-  const tvlValue = data?.tvl ? `$${formatTvl(data.tvl)}` : '$000M';
-  const totalRevenueValue = data?.totalRevenueUsd
-    ? `$${formatTvl(data.totalRevenueUsd)}`
+  const tvlValue = hasTvl ? `$${formatTvl(tvl)}` : '$000M';
+  const totalRevenueValue = hasTotalRevenue
+    ? `$${formatTvl(totalRevenueUsd)}`
     : '$00.0M';
   return (
     <section
@@ -57,7 +72,10 @@ export default function LunarCircleSection() {
                 className='flex w-full flex-col items-start gap-2 px-4'
               >
                 <div className='font-cinzel text-3xl leading-[110%] font-normal text-white'>
-                  <BlurredLoadingText text={tvlValue} isLoading={loading} />
+                  <BlurredLoadingText
+                    text={tvlValue}
+                    isLoading={loading || !hasTvl}
+                  />
                 </div>
                 <div className='font-cinzel text-sm leading-[110%] font-normal text-white/60 uppercase'>
                   &#123; Total Deposits &#125;
@@ -75,7 +93,7 @@ export default function LunarCircleSection() {
                 <div className='font-cinzel text-3xl leading-[110%] font-normal text-white'>
                   <BlurredLoadingText
                     text={allTimeTransactions}
-                    isLoading={loading}
+                    isLoading={loading || !hasTotalTransactions}
                   />
                 </div>
                 <div className='font-cinzel text-sm leading-[110%] font-normal text-white/60 uppercase'>
@@ -315,7 +333,10 @@ export default function LunarCircleSection() {
                 className='flex w-full flex-col items-start gap-2 px-4'
               >
                 <div className='font-cinzel text-3xl leading-[110%] font-normal text-white'>
-                  <BlurredLoadingText text={activeUsers} isLoading={loading} />
+                  <BlurredLoadingText
+                    text={activeUsers}
+                    isLoading={loading || !hasUniqueUsers}
+                  />
                 </div>
                 <div className='font-cinzel text-sm leading-[110%] font-normal text-white/60 uppercase'>
                   &#123; ACTIVE USERS &#125;
@@ -333,7 +354,7 @@ export default function LunarCircleSection() {
                 <div className='font-cinzel text-3xl leading-[110%] font-normal text-white'>
                   <BlurredLoadingText
                     text={totalRevenueValue}
-                    isLoading={loading}
+                    isLoading={loading || !hasTotalRevenue}
                   />
                 </div>
                 <div className='font-cinzel text-sm leading-[110%] font-normal text-white/60 uppercase'>
@@ -594,7 +615,10 @@ export default function LunarCircleSection() {
                 {/* Total Deposits */}
                 <div className='flex w-[120px] flex-col items-center gap-2 md:w-[158px] md:items-start md:gap-3'>
                   <div className='font-cinzel mt-[-1px] text-3xl leading-[110%] font-normal text-white md:w-[158px] md:text-left md:text-5xl'>
-                    <BlurredLoadingText text={tvlValue} isLoading={loading} />
+                    <BlurredLoadingText
+                      text={tvlValue}
+                      isLoading={loading || !hasTvl}
+                    />
                   </div>
                   <div className='relative h-8 w-full md:h-10'>
                     <div className='font-cinzel absolute top-0 left-0 h-[16px] w-full text-lg leading-[110%] font-normal text-white/60 uppercase md:h-[18px]'>
@@ -611,7 +635,7 @@ export default function LunarCircleSection() {
                   <div className='font-cinzel mt-[-1px] text-3xl leading-[110%] font-normal text-white md:w-[158px] md:text-left md:text-5xl'>
                     <BlurredLoadingText
                       text={allTimeTransactions}
-                      isLoading={loading}
+                      isLoading={loading || !hasTotalTransactions}
                     />
                   </div>
                   <div className='relative h-8 w-full px-0.5 md:h-10'>
@@ -638,7 +662,7 @@ export default function LunarCircleSection() {
                   <div className='font-cinzel mt-[-1px] text-3xl leading-[110%] font-normal text-white md:w-[158px] md:text-left md:text-5xl'>
                     <BlurredLoadingText
                       text={totalRevenueValue}
-                      isLoading={loading}
+                      isLoading={loading || !hasTotalRevenue}
                     />
                   </div>
                   <div className='flex flex-col items-center gap-0 md:relative md:h-10 md:w-full md:items-start'>
@@ -656,7 +680,7 @@ export default function LunarCircleSection() {
                   <div className='font-cinzel mt-[-1px] text-3xl leading-[110%] font-normal text-white md:w-[158px] md:text-left md:text-5xl'>
                     <BlurredLoadingText
                       text={activeUsers}
-                      isLoading={loading}
+                      isLoading={loading || !hasUniqueUsers}
                     />
                   </div>
                   <div className='flex flex-col items-center gap-0 md:relative md:h-10 md:w-full md:items-start'>

--- a/src/components/ui/ScreenshotButton.tsx
+++ b/src/components/ui/ScreenshotButton.tsx
@@ -6,17 +6,23 @@ import { CameraIcon } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { formatTvl } from '@/lib/TvlContext';
-import { useUserbaseContext } from '@/lib/UserbaseContext';
+import { hasStatValue, useUserbaseContext } from '@/lib/UserbaseContext';
 
 export function ScreenshotButton() {
   const canvasRef = useRef<HTMLDivElement>(null);
   const [isGenerating, setIsGenerating] = useState(false);
   const { data } = useUserbaseContext();
 
-  const tvlValue = data?.tvl ? `$${formatTvl(data.tvl)}` : '$0.00M';
-  const revenueValue = data?.totalRevenueUsd
-    ? `$${formatTvl(data.totalRevenueUsd)}`
-    : '$0.00M';
+  // html2canvas cannot reproduce the loading blur, so a stat the backend
+  // never delivered is left out of the shot entirely instead of being
+  // captured as a zero.
+  const tvl = data?.tvl;
+  const totalRevenueUsd = data?.totalRevenueUsd;
+  const hasTvl = hasStatValue(tvl);
+  const hasTotalRevenue = hasStatValue(totalRevenueUsd);
+
+  const tvlValue = hasTvl ? `$${formatTvl(tvl)}` : '';
+  const revenueValue = hasTotalRevenue ? `$${formatTvl(totalRevenueUsd)}` : '';
 
   const handleScreenshot = useCallback(async () => {
     if (!canvasRef.current || isGenerating) return;
@@ -260,82 +266,86 @@ export function ScreenshotButton() {
           }}
         >
           {/* TVL Card */}
-          <div
-            style={{
-              width: '200px',
-              height: '90px',
-              borderRadius: '18px',
-              backgroundColor: 'rgba(69, 1, 109, 0.7)',
-              border: '1px solid rgba(255, 255, 255, 0.2)',
-              padding: '12px',
-              boxSizing: 'border-box',
-              boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4)',
-            }}
-          >
+          {hasTvl && (
             <div
               style={{
-                fontFamily: 'Cinzel, serif',
-                fontSize: '11px',
-                fontWeight: 400,
-                color: '#ead5ff',
-                textTransform: 'uppercase',
-                lineHeight: '1.1',
+                width: '200px',
+                height: '90px',
+                borderRadius: '18px',
+                backgroundColor: 'rgba(69, 1, 109, 0.7)',
+                border: '1px solid rgba(255, 255, 255, 0.2)',
+                padding: '12px',
+                boxSizing: 'border-box',
+                boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4)',
               }}
             >
-              Total Deposits
+              <div
+                style={{
+                  fontFamily: 'Cinzel, serif',
+                  fontSize: '11px',
+                  fontWeight: 400,
+                  color: '#ead5ff',
+                  textTransform: 'uppercase',
+                  lineHeight: '1.1',
+                }}
+              >
+                Total Deposits
+              </div>
+              <div
+                style={{
+                  marginTop: '14px',
+                  fontFamily: 'Cinzel, serif',
+                  fontSize: '28px',
+                  fontWeight: 400,
+                  color: 'white',
+                  lineHeight: '1.1',
+                }}
+              >
+                {tvlValue}
+              </div>
             </div>
-            <div
-              style={{
-                marginTop: '14px',
-                fontFamily: 'Cinzel, serif',
-                fontSize: '28px',
-                fontWeight: 400,
-                color: 'white',
-                lineHeight: '1.1',
-              }}
-            >
-              {tvlValue}
-            </div>
-          </div>
+          )}
 
           {/* Revenue Card */}
-          <div
-            style={{
-              width: '200px',
-              height: '90px',
-              borderRadius: '18px',
-              backgroundColor: 'rgba(69, 1, 109, 0.7)',
-              border: '1px solid rgba(255, 255, 255, 0.2)',
-              padding: '12px',
-              boxSizing: 'border-box',
-              boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4)',
-            }}
-          >
+          {hasTotalRevenue && (
             <div
               style={{
-                fontFamily: 'Cinzel, serif',
-                fontSize: '11px',
-                fontWeight: 400,
-                color: '#ead5ff',
-                textTransform: 'uppercase',
-                lineHeight: '1.1',
+                width: '200px',
+                height: '90px',
+                borderRadius: '18px',
+                backgroundColor: 'rgba(69, 1, 109, 0.7)',
+                border: '1px solid rgba(255, 255, 255, 0.2)',
+                padding: '12px',
+                boxSizing: 'border-box',
+                boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4)',
               }}
             >
-              Total Revenue
+              <div
+                style={{
+                  fontFamily: 'Cinzel, serif',
+                  fontSize: '11px',
+                  fontWeight: 400,
+                  color: '#ead5ff',
+                  textTransform: 'uppercase',
+                  lineHeight: '1.1',
+                }}
+              >
+                Total Revenue
+              </div>
+              <div
+                style={{
+                  marginTop: '14px',
+                  fontFamily: 'Cinzel, serif',
+                  fontSize: '28px',
+                  fontWeight: 400,
+                  color: 'white',
+                  lineHeight: '1.1',
+                }}
+              >
+                {revenueValue}
+              </div>
             </div>
-            <div
-              style={{
-                marginTop: '14px',
-                fontFamily: 'Cinzel, serif',
-                fontSize: '28px',
-                fontWeight: 400,
-                color: 'white',
-                lineHeight: '1.1',
-              }}
-            >
-              {revenueValue}
-            </div>
-          </div>
+          )}
         </div>
       </div>
     </>

--- a/src/lib/TvlContext.tsx
+++ b/src/lib/TvlContext.tsx
@@ -98,7 +98,10 @@ export function useTvlContext() {
  * @returns Formatted string (e.g., "425.85K" or "1.23M")
  */
 export function formatTvl(tvl: string | number): string {
-  const value = typeof tvl === 'string' ? parseFloat(tvl) : tvl;
+  // Same full-string conversion as hasStatValue: the guard and the formatter
+  // must read a value identically, or a string the guard admits can format
+  // into a different number than it was admitted for.
+  const value = typeof tvl === 'string' ? Number(tvl) : tvl;
 
   if (value >= 1_000_000) {
     return `${(value / 1_000_000).toFixed(2)}M`;

--- a/src/lib/UserbaseContext.tsx
+++ b/src/lib/UserbaseContext.tsx
@@ -187,7 +187,10 @@ export function hasStatValue(
     return false;
   }
 
-  const numeric = typeof value === 'string' ? parseFloat(value) : value;
+  // Number() and not parseFloat(): the latter parses a leading prefix, so
+  // "12invalid" would pass as 12 and "1,234" as 1, publishing an invented
+  // figure as a measurement. The whole string has to be a number.
+  const numeric = typeof value === 'string' ? Number(value) : value;
   return Number.isFinite(numeric) && numeric > 0;
 }
 

--- a/src/lib/UserbaseContext.tsx
+++ b/src/lib/UserbaseContext.tsx
@@ -20,10 +20,12 @@ const ENVIO_GRAPHQL_URL =
 const CACHE_DURATION = 5 * 60 * 1000;
 
 interface TvlData {
-  tvl: string;
-  tvlRaw: number;
-  totalBorrowed: string;
-  totalBorrowedRaw: number;
+  // The endpoint answers 200 with nulls when the market totals are
+  // unavailable, so nothing sourced from them is guaranteed to be a number.
+  tvl: string | null;
+  tvlRaw: number | null;
+  totalBorrowed: string | null;
+  totalBorrowedRaw: number | null;
   activeReserves: number;
   totalReserves: number;
   timestamp: string;
@@ -106,23 +108,44 @@ export function UserbaseProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    try {
-      setLoading(true);
-      const [tvlData, protocolStats] = await Promise.all([
-        fetchTvlData(),
-        fetchProtocolStats(),
-      ]);
+    setLoading(true);
 
-      setData({ ...tvlData, ...protocolStats });
-      setError(null);
-      lastFetchTime.current = now;
-      // Only stop loading on success
-      setLoading(false);
-    } catch (err) {
-      console.error('Error fetching stats:', err);
-      setError(err instanceof Error ? err : new Error('Unknown error'));
-      // Keep loading=true on error to maintain blur effect
+    // Settled rather than all: one failing source must only cost its own
+    // stats, never drag the figures that did arrive back behind the blur.
+    const [tvlResult, statsResult] = await Promise.allSettled([
+      fetchTvlData(),
+      fetchProtocolStats(),
+    ]);
+
+    const failures = [tvlResult, statsResult]
+      .filter((result) => result.status === 'rejected')
+      .map((result) => result.reason);
+
+    failures.forEach((reason) =>
+      console.error('Error fetching stats:', reason),
+    );
+
+    if (tvlResult.status === 'rejected' && statsResult.status === 'rejected') {
+      setError(
+        failures[0] instanceof Error ? failures[0] : new Error('Unknown error'),
+      );
+      // Nothing usable arrived: stay loading so every stat keeps its blur.
+      return;
     }
+
+    setData({
+      ...(tvlResult.status === 'fulfilled' ? tvlResult.value : {}),
+      ...(statsResult.status === 'fulfilled' ? statsResult.value : {}),
+    });
+    setError(
+      failures.length === 0
+        ? null
+        : failures[0] instanceof Error
+          ? failures[0]
+          : new Error('Unknown error'),
+    );
+    lastFetchTime.current = now;
+    setLoading(false);
   };
 
   useEffect(() => {
@@ -147,6 +170,25 @@ export function useUserbaseContext() {
     );
   }
   return context;
+}
+
+/**
+ * Whether a stat actually came back from the backend and can be shown.
+ *
+ * A missing, malformed or zero figure is never a real measurement, so it must
+ * keep its blurred placeholder instead of being published as a number.
+ * @param value - Raw stat value as delivered by the API
+ * @returns True only for a finite value greater than zero
+ */
+export function hasStatValue(
+  value: string | number | null | undefined,
+): value is string | number {
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  const numeric = typeof value === 'string' ? parseFloat(value) : value;
+  return Number.isFinite(numeric) && numeric > 0;
 }
 
 /**


### PR DESCRIPTION
The TVL endpoint answers HTTP 200 with `"tvl": null` whenever the lending market totals are unavailable, which is what it is doing right now (`"lendingTotalsSource": "unavailable"`). Because the fetch succeeded, `loading` flipped to false and both stat sections fell through to their hardcoded placeholder, so the landing page rendered a fully legible `$000.00M` under "Total Deposits" as if that were the measured figure. Blur was only retained when the fetch itself threw. A stat now stays behind its loading blur unless the backend hands back a real figure, and that decision is made per stat rather than for the whole page.

## Data layer

`hasStatValue()` in `src/lib/UserbaseContext.tsx` is the single answer to "is this a real measurement": `null`, `undefined`, a non-finite parse, and zero all return false. It is written as a TypeScript type predicate (`value is string | number`), so a call site that guards on it narrows the value and can pass it straight to `formatTvl` without assertions. `TvlData.tvl`, `tvlRaw`, `totalBorrowed` and `totalBorrowedRaw` are widened to allow `null`, which is what the endpoint has always been able to return; the interface previously claimed they were always populated.

The two sources are fetched with `Promise.allSettled` instead of `Promise.all`. Under `Promise.all` a single rejection discarded the sibling result and left the shared `loading` flag pinned true, so a dead TVL endpoint blurred revenue, transactions and users along with it. Each source now only costs its own stats: whatever resolved is merged into `data` and rendered, and the rejection is logged and surfaced through `error`. When both reject there is nothing usable to show, so the provider returns without clearing `loading` or stamping `lastFetchTime`, and every stat keeps its blur.

## Stat rendering

`HeroSection.tsx` and `LunarCircleSection.tsx` resolve one `has*` flag per stat and gate the blur on `loading || !hasStat`, across all 12 render sites: four `StatsCard` instances in the hero (desktop and mobile, deposits and revenue) and eight `BlurredLoadingText` instances in the lunar section (its mobile and desktop layouts each render deposits, transactions, revenue and users). The placeholder strings are unchanged; they are simply never shown unblurred any more. With the endpoint in its current state that means Total Deposits reads as an animated smear while revenue, transactions and users render normally.

## Screenshot capture

`ScreenshotButton.tsx` composes an offscreen replica that html2canvas rasterizes, and html2canvas does not reproduce a CSS `filter`, so there is no blurred state to capture. A stat card whose value is missing is dropped from the replica entirely rather than baked into the PNG as `$0.00M`. Most of this file's diff is Prettier reindentation from wrapping the two cards in conditionals. The component is not currently mounted anywhere in the app.

## Verification

`tsc --noEmit`, `eslint`, `prettier --check` and `next build` were run against this branch and are clean. Behavior was checked in headless Chromium against `next dev` while the live endpoint was returning `"tvl": null`, reading computed styles off the DOM: the Total Deposits value carries `filter: blur(9px)` at `opacity: 0.9` and keeps animating, while `$3.67M`, `774,411` and `11,289` all render at `filter: none`. The same holds at a 390px viewport.

No automated test was added. The `vitest.config.ts` `projects` array contains only the Storybook browser project, so the existing `src/**/*.test.tsx` files are not part of any run and a new one there would not execute either.